### PR TITLE
Gracefully handling CSRF token expiration error

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Middleware;
 
+use Closure;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+use Illuminate\Session\TokenMismatchException;
 
 class VerifyCsrfToken extends Middleware
 {
@@ -14,4 +16,16 @@ class VerifyCsrfToken extends Middleware
     protected $except = [
         //
     ];
+
+    public function handle($request, Closure $next)
+    {
+        try {
+            return parent::handle($request, $next);
+        }
+        catch (TokenMismatchException $exception) {
+            return redirect()->back()->withErrors([
+                'message' => 'Your Session have expired. Try again.',
+            ]);
+        }
+    }
 }


### PR DESCRIPTION
- redirecting back with an error message when CSRF token has expired